### PR TITLE
Fix fallback logic in page chunk processing to prevent irrelevant results

### DIFF
--- a/backend/llm_service.py
+++ b/backend/llm_service.py
@@ -261,11 +261,7 @@ class LLMService:
         except Exception as e:
             chunk_time = time.time() - chunk_start
             print(f"    ❌ Chunk {chunk_index + 1} failed in {chunk_time:.2f}s: {e}")
-            # Fallback: include first page of chunk
-            if chunk:
-                first_page = chunk[0].copy()
-                first_page["source_document"] = filename
-                return [first_page], 0.0
+            # Return empty result - better than returning irrelevant pages
             return [], 0.0
 
     async def generate_answer_stream(


### PR DESCRIPTION
Thank you for building such a well-structured PDF chatbot system! The codebase is clean and the three-step processing pipeline (document selection → page detection → answer generation) is really thoughtfully designed. I hope this small improvement helps make the search results even more reliable.

---


## Problem
When JSON parsing fails in `_process_page_chunk()`, the current fallback returns the first page of the chunk regardless of relevance. This can lead to misleading search results where users receive confident answers from completely unrelated content.

## Solution
- Remove the fallback that returns `first_page` when parsing fails
- Return empty array `[]` instead
- This ensures only genuinely relevant pages are included in results

## Impact
- Prevents false positive results in document search
- Maintains result accuracy when some chunks fail to process
- No breaking changes to existing functionality

Fixes the edge case where parsing errors could pollute search results with irrelevant content.